### PR TITLE
resolves gh-18, show results headers on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,11 +32,11 @@
   }
 }
 
-#notes-print-area {
+#notes-print-area, .results-table-header {
   display: none;
 }
 
-@media print {
+@media only print {
   div.ui.grid {
     display: none !important;
   }
@@ -50,8 +50,12 @@
   }
 }
 
-@media (max-width: 767px) {
+@media only screen and (max-width: 767px) {
   table.ui.table thead {
     display: none !important;
+  }
+
+  .results-table-header {
+    display: inline;
   }
 }

--- a/src/components/ConvictionResults.jsx
+++ b/src/components/ConvictionResults.jsx
@@ -57,15 +57,21 @@ const ConvictionResults = ({
           {convictions.map(({ id, crime, vacatable, reasons }) =>
             <Table.Row key={id}>
               <Table.Cell>
+                <b className='results-table-header'>{`${Headers[0].text}: `}</b>
                 {id}
               </Table.Cell>
               <Table.Cell>
+                <b className='results-table-header'>{`${Headers[1].text.slice(0, -1)}: `}</b>
                 {crime}
               </Table.Cell>
-              <Table.Cell style={{color: vacatable ? 'green' : 'red'}}>
-                <b>{vacatable ? 'Yes': 'No'}</b>
+              <Table.Cell>
+                <b className='results-table-header'>{`${Headers[2].text}: `}</b>
+                <b style={{ color: vacatable ? 'green' : 'red' }}>
+                  {vacatable ? 'Yes' : 'No'}
+                </b>
               </Table.Cell>
               <Table.Cell>
+                <b className='results-table-header'>{`${Headers[3].text}: `}</b>
                 <List bulleted>
                   {reasons.map(reason => <List.Item key={reason}>{reason}</List.Item>)}
                 </List>


### PR DESCRIPTION
Resolves #18.

Show table headers next to results on mobile.

![Screen Shot 2019-10-18 at 10 49 56](https://user-images.githubusercontent.com/37560480/67116469-4fa2c800-f195-11e9-903e-91a525f04da4.png)
