### PR TITLE
Add Felony class A; remove unnecessary tests

### DIFF
--- a/src/logic/EligibilityTimelineCalculator.js
+++ b/src/logic/EligibilityTimelineCalculator.js
@@ -14,6 +14,17 @@ export default class EligibilityTimelineCalculator {
         let calculationDate = moment(input.calculationDate);
         let clientDOB = moment(input.clientDOB);
 
+        // 0. Determine non-vacatable things:
+        // check for class A
+        input.convictions.forEach((conviction) => {
+            let convictionOutput = output.getConviction(conviction.id);
+            if (conviction.classification === CrimeClassification.FELONY_CLASS_A) {
+            convictionOutput.reasons.notVacatableReasons.push(
+                'Conviction involves Felony Class A, not vacatable.'
+                );
+            }
+        });
+
         // 1. Determine the most recent conviction date, then check whether date between NOW and the date
         //    recent conviction will make any of the convictions ineligible for vacation
         //      Misdemeanor & Gross Misdemeanor - no new conviction in the past 3 years
@@ -66,6 +77,9 @@ export default class EligibilityTimelineCalculator {
                             `The latest conviction date ${lastConvictionDateString} is within the last 5 years.`
                         );
                     }
+                    break;
+                case CrimeClassification.FELONY_CLASS_A:
+                        console.log("Yes");
                     break;
                 default:
                     convictionOutput.reasons.errors.push("Crime Classification not specified.");
@@ -133,6 +147,7 @@ export default class EligibilityTimelineCalculator {
             let relevantDateString = relevantDate.format('YYYY-MM-DD')
             let yearsSinceRelevantDate = calculationDate.diff(relevantDate, 'years');
 
+
             // TODO: Verify if this is only applicable to Felonies
             if (conviction.classification === CrimeClassification.FELONY_CLASS_C ||
                 conviction.classification === CrimeClassification.FELONY_CLASS_B) {
@@ -172,6 +187,7 @@ export default class EligibilityTimelineCalculator {
 
         });
 
+
         this.setEligibilityProperty(output);
 
         return output;
@@ -198,6 +214,7 @@ export default class EligibilityTimelineCalculator {
     setEligibilityProperty(output) {
         output.convictions.forEach((conviction) => {
             if (conviction.reasons.errors.length > 0) {
+                console.log("error, null return");
                 conviction.vacatable = null;
             } else if (conviction.reasons.notVacatableReasons.length > 0) {
                 conviction.vacatable = false;

--- a/src/logic/EligibilityTimelineCalculator.test.js
+++ b/src/logic/EligibilityTimelineCalculator.test.js
@@ -2,6 +2,7 @@ import moment, { isDuration } from 'moment';
 
 import ConvictionCalculator from './EligibilityTimelineCalculator';
 
+// import CrimeClassification from "./type/CrimesClassifications";
 import CrimeClassification from "./type/CrimesClassifications";
 import {
     ConvictionInput,
@@ -22,6 +23,7 @@ let singleConvictionTestData = [
     ["Felony C Before 1st July, 1984", CrimeClassification.FELONY_CLASS_C, false, false, "1984-06-30", "2019-01-01", "2019-11-01", false],
     ["Marijuana possesion, under 21 at offense time", CrimeClassification.MARIJUANA_MISDEMEANOR, false, false, "2019-06-30", "2019-11-01", "1999-01-01", false],
     ["Marijuana possesion, 21+ at offense time", CrimeClassification.MARIJUANA_MISDEMEANOR, false, false, "2019-06-30", "2019-11-01", "1990-01-01", true],
+    ["Felony A, 21+ at offense time", CrimeClassification.FELONY_CLASS_A, false, false, "2019-06-30", "2019-11-01", "1990-01-01", false]
 ]
 test.each(singleConvictionTestData)(
     'Single conviction with crime="%s", classification="%s", withDomesticViolence="%s" and isDUI="%s" relevant date of "%s" and calculationDate="%s"',
@@ -30,7 +32,8 @@ test.each(singleConvictionTestData)(
         let conviction = new ConvictionInput(TEST_ID, crime, classification, isDV, isDUI, relevantDate);
         let input = new CalculatorInput(calculationDate, clientDOB, [conviction]);
         let actualCalculatorOutput = calculator.calculate(input);
-
+        console.log(input);
+        console.log(actualCalculatorOutput);
         expect(actualCalculatorOutput.getConviction(TEST_ID).vacatable).toBe(expectedVacatable);
     },);
 

--- a/src/logic/type/CrimesClassifications.js
+++ b/src/logic/type/CrimesClassifications.js
@@ -1,6 +1,5 @@
 export default {
-    // Class A Felony is by definition NOT vacatable, and are not presented as options
-    // "FELONY_CLASS_A": "FELONY_CLASS_A",
+    "FELONY_CLASS_A": "FELONY_CLASS_A",
     "FELONY_CLASS_B": "FELONY_CLASS_B",
     "FELONY_CLASS_C": "FELONY_CLASS_C",
     "MISDEMEANOR": "MISDEMEANOR",

--- a/src/logic/type/CrimesClassifications.test.js
+++ b/src/logic/type/CrimesClassifications.test.js
@@ -1,7 +1,0 @@
-import CrimeClassification from './CrimesClassifications.js';
-
-test('Should not contain class A felonies', () => {
-    Object.keys(CrimeClassification).forEach(classification => {
-        expect(classification.toLowerCase()).toEqual(expect.not.stringContaining("class_a"));
-    });
-});


### PR DESCRIPTION

- [ ] Add felony class A as a crime classification; When felony class A was committed, the conviction won't vacate.
- [ ] Made the change in "EligibilityTimelineCalculator.js", in step 0.
- [ ] Add a test case in "EligibilityTimelineCalculator.test.js" to show that felony class A will not vacate.



